### PR TITLE
Enhance draft tool with rosters, filters, and PAR valuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,17 @@
     <button data-tab="settings">Settings</button>
     <button data-tab="projections">Projections</button>
     <button data-tab="draft">Draft</button>
+    <button data-tab="rosters">Rosters</button>
   </nav>
 
     <section id="settings" class="tab">
       <h2>League Settings</h2>
       <div class="row">
-      <label>Teams: <input id="teams" type="number" value="10" min="1"/></label>
-      <label>Budget per Team: <input id="budget" type="number" value="200" min="1"/></label>
-      <label>Season: <input id="season" type="number" value="2025" min="1900"/></label>
+        <label>Teams: <input id="teams" type="number" value="10" min="1"/></label>
+        <label>Budget per Team: <input id="budget" type="number" value="200" min="1"/></label>
+        <label>Season: <input id="season" type="number" value="2025" min="1900"/></label>
       </div>
+      <label>Team Names (comma separated): <input id="team-names" type="text" /></label>
       <h3>Scoring Weights</h3>
       <div id="weights"></div>
       <button id="apply">Apply Settings</button>
@@ -26,6 +28,11 @@
 
   <section id="projections" class="tab" hidden>
     <h2>Player Projections</h2>
+    <div id="projection-filters" class="filters">
+      <input id="filter-name" placeholder="Search player" />
+      <select id="filter-team"></select>
+      <select id="filter-pos"></select>
+    </div>
     <table id="projections-table">
       <thead>
         <tr>
@@ -42,12 +49,17 @@
     <table id="draft-table">
       <thead>
         <tr>
-          <th>Player</th><th>FPPG</th><th>PAR</th><th>Value ($)</th><th></th>
+          <th>Player</th><th>FPPG</th><th>PAR</th><th>Value ($)</th><th>Team</th><th>Bid</th><th></th>
         </tr>
       </thead>
       <tbody></tbody>
     </table>
     <div id="budget-info"></div>
+  </section>
+
+  <section id="rosters" class="tab" hidden>
+    <h2>Team Rosters</h2>
+    <div id="roster-list"></div>
   </section>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -35,12 +35,16 @@ let budgetPerTeam = 200;
 let season = 2025;
 let teamBudgets = Array(teamCount).fill(budgetPerTeam);
 let spent = 0;
+let teamNames = Array.from({ length: teamCount }, (_, i) => `Team ${i + 1}`);
+let rosters = Array.from({ length: teamCount }, () => []);
 
 if (isBrowser) {
   document.addEventListener("DOMContentLoaded", () => {
     initTabs();
     renderWeightInputs();
     document.getElementById("apply").addEventListener("click", applySettings);
+    document.getElementById('team-names').value = teamNames.join(', ');
+    renderRosters();
     loadPlayers();
   });
 }
@@ -79,18 +83,26 @@ function applySettings() {
   budgetPerTeam = Number.isFinite(b) && b > 0 ? b : budgetPerTeam;
   const oldSeason = season;
   season = Number.isInteger(s) ? s : season;
+  const namesInput = document.getElementById('team-names').value.trim();
+  teamNames = namesInput ? namesInput.split(',').map(n => n.trim()).filter(Boolean) : [];
+  while (teamNames.length < teamCount) teamNames.push(`Team ${teamNames.length + 1}`);
+  teamNames = teamNames.slice(0, teamCount);
+  document.getElementById('team-names').value = teamNames.join(', ');
   document.querySelectorAll('#weights input').forEach(input => {
     const val = parseFloat(input.value);
     weights[input.dataset.cat] = Number.isFinite(val) ? val : 0;
   });
   teamBudgets = Array(teamCount).fill(budgetPerTeam);
   spent = 0;
+  rosters = Array.from({ length: teamCount }, () => []);
   if (season !== oldSeason) {
     loadPlayers();
   } else {
     players.forEach(p => { p.fppg = calcFPPG(p); });
+    populateFilters();
     renderProjections();
     renderDraft();
+    renderRosters();
   }
 }
 
@@ -105,8 +117,10 @@ function loadPlayers() {
       players = Array.isArray(data.data) ? data.data.map(mapApiPlayer) : [];
       players.forEach(p => { p.fppg = calcFPPG(p); });
       undrafted = new Set(players.map(p => p.name));
+      populateFilters();
       renderProjections();
       renderDraft();
+      renderRosters();
     })
     .catch(err => {
       console.error('Failed to load from API, falling back to players.json', err);
@@ -119,8 +133,10 @@ function loadPlayers() {
           players = Array.isArray(data) ? data : [];
           players.forEach(p => { p.fppg = calcFPPG(p); });
           undrafted = new Set(players.map(p => p.name));
+          populateFilters();
           renderProjections();
           renderDraft();
+          renderRosters();
         })
         .catch(err2 => {
           console.error('Failed to load players.json', err2);
@@ -164,17 +180,52 @@ function calcFPPG(p, w = weights) {
   );
 }
 
+function populateFilters() {
+  if (!isBrowser) return;
+  const teamSelect = document.getElementById('filter-team');
+  const posSelect = document.getElementById('filter-pos');
+  const teams = Array.from(new Set(players.map(p => p.team))).sort();
+  const positions = Array.from(new Set(players.map(p => p.pos))).sort();
+  teamSelect.innerHTML = '<option value="">All Teams</option>';
+  teams.forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    teamSelect.appendChild(opt);
+  });
+  posSelect.innerHTML = '<option value="">All Positions</option>';
+  positions.forEach(pos => {
+    const opt = document.createElement('option');
+    opt.value = pos;
+    opt.textContent = pos;
+    posSelect.appendChild(opt);
+  });
+  document.getElementById('filter-name').oninput = renderProjections;
+  teamSelect.onchange = renderProjections;
+  posSelect.onchange = renderProjections;
+}
+
 function renderProjections() {
+  if (!isBrowser) return;
   const tbody = document.querySelector('#projections-table tbody');
   tbody.innerHTML = '';
-  players.forEach(p => {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${p.name}</td><td>${p.team}</td><td>${p.pos}</td>` +
-      `<td>${p.pts}</td><td>${p.reb}</td><td>${p.ast}</td>` +
-      `<td>${p.stl}</td><td>${p.blk}</td><td>${p.tov}</td>` +
-      `<td>${p.fppg.toFixed(1)}</td>`;
-    tbody.appendChild(tr);
-  });
+  const nameFilter = document.getElementById('filter-name').value.toLowerCase();
+  const teamFilter = document.getElementById('filter-team').value;
+  const posFilter = document.getElementById('filter-pos').value;
+  players
+    .filter(p =>
+      p.name.toLowerCase().includes(nameFilter) &&
+      (!teamFilter || p.team === teamFilter) &&
+      (!posFilter || p.pos === posFilter)
+    )
+    .forEach(p => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${p.name}</td><td>${p.team}</td><td>${p.pos}</td>` +
+        `<td>${p.pts}</td><td>${p.reb}</td><td>${p.ast}</td>` +
+        `<td>${p.stl}</td><td>${p.blk}</td><td>${p.tov}</td>` +
+        `<td>${p.fppg.toFixed(1)}</td>`;
+      tbody.appendChild(tr);
+    });
 }
 
 function computeValues() {
@@ -184,8 +235,10 @@ function computeValues() {
 function computeValuesFor(list, undraftedSet, tCount, bPerTeam, spentTotal, budgets) {
   const remaining = list.filter(p => undraftedSet.has(p.name));
   if (remaining.length === 0) return { replacement: 0, totalPAR: 0, budgetLeft: 0 };
-  const replacement = Math.min(...remaining.map(p => p.fppg));
-  remaining.forEach(p => { p.par = p.fppg - replacement; });
+  const sorted = remaining.map(p => p.fppg).sort((a, b) => b - a);
+  const index = Math.min(129, sorted.length - 1);
+  const replacement = sorted[index];
+  remaining.forEach(p => { p.par = Math.max(0, p.fppg - replacement); });
   const totalPAR = remaining.reduce((sum, p) => sum + Math.max(0, p.par), 0);
   const budgetLeft = budgets ? budgets.reduce((a, b) => a + b, 0)
     : tCount * bPerTeam - spentTotal;
@@ -197,6 +250,7 @@ function computeValuesFor(list, undraftedSet, tCount, bPerTeam, spentTotal, budg
 
 function renderDraft() {
   computeValues();
+  if (!isBrowser) return;
   const tbody = document.querySelector('#draft-table tbody');
   tbody.innerHTML = '';
   players.filter(p => undrafted.has(p.name)).forEach(p => {
@@ -204,10 +258,42 @@ function renderDraft() {
     tr.innerHTML = `<td>${p.name}</td><td>${p.fppg.toFixed(1)}</td>` +
       `<td>${p.par ? p.par.toFixed(1) : '0'}</td>` +
       `<td>${p.value ? p.value.toFixed(1) : '0'}</td>`;
+    const teamTd = document.createElement('td');
+    const select = document.createElement('select');
+    teamNames.forEach((name, idx) => {
+      const opt = document.createElement('option');
+      opt.value = idx;
+      opt.textContent = name;
+      select.appendChild(opt);
+    });
+    teamTd.appendChild(select);
+    tr.appendChild(teamTd);
+    const priceTd = document.createElement('td');
+    const priceInput = document.createElement('input');
+    priceInput.type = 'number';
+    priceInput.min = '0';
+    priceInput.step = '0.1';
+    priceInput.value = p.value ? p.value.toFixed(1) : '0';
+    priceTd.appendChild(priceInput);
+    tr.appendChild(priceTd);
     const td = document.createElement('td');
     const btn = document.createElement('button');
     btn.textContent = 'Draft';
-    btn.addEventListener('click', () => draftPlayer(p));
+    btn.addEventListener('click', () => {
+      const teamIndex = parseInt(select.value, 10);
+      const price = parseFloat(priceInput.value);
+      if (!Number.isFinite(price) || price <= 0) return;
+      if (price > teamBudgets[teamIndex]) {
+        alert('Bid exceeds team budget');
+        return;
+      }
+      teamBudgets[teamIndex] -= price;
+      spent += price;
+      undrafted.delete(p.name);
+      rosters[teamIndex].push({ player: p, price });
+      renderDraft();
+      renderRosters();
+    });
     td.appendChild(btn);
     tr.appendChild(td);
     tbody.appendChild(tr);
@@ -218,30 +304,31 @@ function renderDraft() {
   const list = document.createElement('ul');
   teamBudgets.forEach((b, i) => {
     const li = document.createElement('li');
-    li.textContent = `Team ${i + 1}: $${b.toFixed(1)}`;
+    li.textContent = `${teamNames[i]}: $${b.toFixed(1)}`;
     list.appendChild(li);
   });
   budgetDiv.appendChild(list);
 }
 
-function draftPlayer(p) {
-  const suggestion = p.value ? p.value.toFixed(1) : '0';
-  const teamInput = prompt(`Winning team (1-${teamCount})`);
-  const teamIndex = parseInt(teamInput, 10) - 1;
-  if (!Number.isInteger(teamIndex) || teamIndex < 0 || teamIndex >= teamCount) {
-    alert('Invalid team number');
-    return;
-  }
-  const price = parseFloat(prompt(`Bid price for ${p.name}`, suggestion));
-  if (!Number.isFinite(price) || price <= 0) return;
-  if (price > teamBudgets[teamIndex]) {
-    alert('Bid exceeds team budget');
-    return;
-  }
-  teamBudgets[teamIndex] -= price;
-  spent += price;
-  undrafted.delete(p.name);
-  renderDraft();
+function renderRosters() {
+  if (!isBrowser) return;
+  const container = document.getElementById('roster-list');
+  container.innerHTML = '';
+  rosters.forEach((team, i) => {
+    const div = document.createElement('div');
+    div.className = 'team-roster';
+    const h3 = document.createElement('h3');
+    h3.textContent = teamNames[i];
+    div.appendChild(h3);
+    const ul = document.createElement('ul');
+    team.forEach(entry => {
+      const li = document.createElement('li');
+      li.textContent = `${entry.player.name} - $${entry.price.toFixed(1)}`;
+      ul.appendChild(li);
+    });
+    div.appendChild(ul);
+    container.appendChild(div);
+  });
 }
 
 if (typeof module !== 'undefined') {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,84 @@
-body { font-family: sans-serif; margin: 1rem; }
-nav { margin-bottom: 1rem; }
-nav button { margin-right: 0.5rem; }
-table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; }
-th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; text-align: left; }
-.row label { margin-right: 1rem; }
-.tab { margin-top: 1rem; }
+/* Theme variables */
+:root {
+  --bg-color: #f5f5f5;
+  --primary-color: #2c3e50;
+  --accent-color: #3498db;
+  --text-color: #2c3e50;
+  --table-stripe: #ecf0f1;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  margin: 0;
+  padding: 0 1rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+nav {
+  background: var(--primary-color);
+  padding: 0.5rem;
+  margin: 0 -1rem 1rem;
+}
+
+nav button {
+  background: var(--accent-color);
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  cursor: pointer;
+}
+
+nav button:hover {
+  opacity: 0.85;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 0.5rem;
+  background: #fff;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+
+th {
+  background: var(--primary-color);
+  color: #fff;
+  position: sticky;
+  top: 0;
+}
+
+tr:nth-child(even) {
+  background: var(--table-stripe);
+}
+
+.row label {
+  margin-right: 1rem;
+}
+
+.tab {
+  margin-top: 1rem;
+}
+
+.filters {
+  margin-top: 0.5rem;
+}
+
+.filters input,
+.filters select {
+  margin-right: 0.5rem;
+}
+
+#draft-table input[type='number'] {
+  width: 4rem;
+}
+
+.team-roster {
+  margin-bottom: 1rem;
+}

--- a/test.js
+++ b/test.js
@@ -21,16 +21,19 @@ if (fppg !== 2) {
   throw new Error(`calcFPPG failed, expected 2 got ${fppg}`);
 }
 
-// Test computeValuesFor
-const players = [
-  { name: 'A', fppg: 10 },
-  { name: 'B', fppg: 5 },
-];
-const undrafted = new Set(['A', 'B']);
+// Test computeValuesFor replacement logic
+const players = Array.from({ length: 140 }, (_, i) => ({ name: String(i), fppg: 140 - i }));
+const undrafted = new Set(players.map(p => p.name));
 const budgets = [100, 100];
-computeValuesFor(players, undrafted, 2, 100, 0, budgets);
-if (Math.round(players[0].value) !== 200 || Math.round(players[1].value) !== 0) {
-  throw new Error('computeValuesFor did not allocate budget correctly');
+const { replacement } = computeValuesFor(players, undrafted, 2, 100, 0, budgets);
+if (replacement !== players[129].fppg) {
+  throw new Error('Replacement player calculation failed');
+}
+if (players[0].par !== players[0].fppg - replacement) {
+  throw new Error('PAR not calculated correctly');
+}
+if (players[130].value !== 0) {
+  throw new Error('Replacement players should have zero value');
 }
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Improve layout with new theme and roster tab
- Add projections filters, team naming, and draft rosters
- Compute player values using 130th-best replacement

## Testing
- `npm test`
- `npm test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a635e73220832285529db6789e7201