### PR TITLE
Refactor into modular architecture

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,336 +1,36 @@
-const isBrowser = typeof window !== 'undefined';
+import { initState, state, applySettingsFromDOM } from './modules/state.js';
+import { initTabs } from './modules/router.js';
+import { renderWeightInputs, populateFilters } from './modules/ui.js';
+import { renderProjections } from './modules/table.js';
+import { renderDraft, renderRosters } from './modules/draft.js';
+import { loadPlayers } from './modules/data-nbaapi.js';
+import { calcFPPG } from './modules/scoring.js';
 
-const categories = {
-  pts: "Points",
-  threepm: "3PM",
-  fga: "FGA",
-  fgm: "FGM",
-  fta: "FTA",
-  ftm: "FTM",
-  reb: "REB",
-  ast: "AST",
-  stl: "STL",
-  blk: "BLK",
-  tov: "TOV"
-};
-
-let weights = {
-  pts: 1,
-  threepm: 1,
-  fga: -1,
-  fgm: 2,
-  fta: -1,
-  ftm: 1,
-  reb: 1,
-  ast: 2,
-  stl: 4,
-  blk: 4,
-  tov: -2
-};
-
-let players = [];
-let undrafted = new Set();
-let teamCount = 10;
-let budgetPerTeam = 200;
-let season = 2025;
-let teamBudgets = Array(teamCount).fill(budgetPerTeam);
-let spent = 0;
-let teamNames = Array.from({ length: teamCount }, (_, i) => `Team ${i + 1}`);
-let rosters = Array.from({ length: teamCount }, () => []);
-
-if (isBrowser) {
-  document.addEventListener("DOMContentLoaded", () => {
+if (typeof window !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', async () => {
+    initState();
     initTabs();
     renderWeightInputs();
-    document.getElementById("apply").addEventListener("click", applySettings);
-    document.getElementById('team-names').value = teamNames.join(', ');
+    document.getElementById('team-names').value = state.teamNames.join(', ');
     renderRosters();
-    loadPlayers();
-  });
-}
-
-function initTabs() {
-  document.querySelectorAll('nav button').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const tab = btn.dataset.tab;
-      document.querySelectorAll('.tab').forEach(s => s.hidden = true);
-      document.getElementById(tab).hidden = false;
-    });
-  });
-}
-
-function renderWeightInputs() {
-  const container = document.getElementById('weights');
-  container.innerHTML = '';
-  Object.entries(weights).forEach(([key, val]) => {
-    const label = document.createElement('label');
-    label.textContent = `${categories[key]}: `;
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.step = '0.1';
-    input.value = val;
-    input.dataset.cat = key;
-    label.appendChild(input);
-    container.appendChild(label);
-  });
-}
-
-function applySettings() {
-  const t = parseInt(document.getElementById('teams').value, 10);
-  const b = parseFloat(document.getElementById('budget').value);
-  const s = parseInt(document.getElementById('season').value, 10);
-  teamCount = Number.isInteger(t) && t > 0 ? t : teamCount;
-  budgetPerTeam = Number.isFinite(b) && b > 0 ? b : budgetPerTeam;
-  const oldSeason = season;
-  season = Number.isInteger(s) ? s : season;
-  const namesInput = document.getElementById('team-names').value.trim();
-  teamNames = namesInput ? namesInput.split(',').map(n => n.trim()).filter(Boolean) : [];
-  while (teamNames.length < teamCount) teamNames.push(`Team ${teamNames.length + 1}`);
-  teamNames = teamNames.slice(0, teamCount);
-  document.getElementById('team-names').value = teamNames.join(', ');
-  document.querySelectorAll('#weights input').forEach(input => {
-    const val = parseFloat(input.value);
-    weights[input.dataset.cat] = Number.isFinite(val) ? val : 0;
-  });
-  teamBudgets = Array(teamCount).fill(budgetPerTeam);
-  spent = 0;
-  rosters = Array.from({ length: teamCount }, () => []);
-  if (season !== oldSeason) {
-    loadPlayers();
-  } else {
-    players.forEach(p => { p.fppg = calcFPPG(p); });
-    populateFilters();
+    state.players = await loadPlayers(state.season, state.weights);
+    state.undrafted = new Set(state.players.map(p => p.name));
+    populateFilters(state.players, renderProjections);
     renderProjections();
     renderDraft();
-    renderRosters();
-  }
-}
 
-function loadPlayers() {
-  const apiUrl = `https://api.server.nbaapi.com/api/playertotals?season=${season}&pageSize=1000`;
-  fetch(apiUrl)
-    .then(r => {
-      if (!r.ok) throw new Error('Network response was not ok');
-      return r.json();
-    })
-    .then(data => {
-      players = Array.isArray(data.data) ? data.data.map(mapApiPlayer) : [];
-      players.forEach(p => { p.fppg = calcFPPG(p); });
-      undrafted = new Set(players.map(p => p.name));
-      populateFilters();
+    document.getElementById('apply').addEventListener('click', async () => {
+      const seasonChanged = applySettingsFromDOM();
+      if (seasonChanged) {
+        state.players = await loadPlayers(state.season, state.weights);
+        state.undrafted = new Set(state.players.map(p => p.name));
+      } else {
+        state.players.forEach(p => { p.fppg = calcFPPG(p, state.weights); });
+      }
+      populateFilters(state.players, renderProjections);
       renderProjections();
       renderDraft();
       renderRosters();
-    })
-    .catch(err => {
-      console.error('Failed to load from API, falling back to players.json', err);
-      fetch('players.json')
-        .then(r => {
-          if (!r.ok) throw new Error('Fallback response was not ok');
-          return r.json();
-        })
-        .then(data => {
-          players = Array.isArray(data) ? data : [];
-          players.forEach(p => { p.fppg = calcFPPG(p); });
-          undrafted = new Set(players.map(p => p.name));
-          populateFilters();
-          renderProjections();
-          renderDraft();
-          renderRosters();
-        })
-        .catch(err2 => {
-          console.error('Failed to load players.json', err2);
-        });
     });
-}
-
-function mapApiPlayer(p) {
-  const g = p.games || 1;
-  return {
-    name: p.playerName,
-    team: p.team,
-    pos: p.position,
-    pts: p.points / g,
-    threepm: p.threeFg / g,
-    fga: p.fieldAttempts / g,
-    fgm: p.fieldGoals / g,
-    fta: p.ftAttempts / g,
-    ftm: p.ft / g,
-    reb: p.totalRb / g,
-    ast: p.assists / g,
-    stl: p.steals / g,
-    blk: p.blocks / g,
-    tov: p.turnovers / g
-  };
-}
-
-function calcFPPG(p, w = weights) {
-  return (
-    (p.pts || 0) * w.pts +
-    (p.threepm || 0) * w.threepm +
-    (p.fga || 0) * w.fga +
-    (p.fgm || 0) * w.fgm +
-    (p.fta || 0) * w.fta +
-    (p.ftm || 0) * w.ftm +
-    (p.reb || 0) * w.reb +
-    (p.ast || 0) * w.ast +
-    (p.stl || 0) * w.stl +
-    (p.blk || 0) * w.blk +
-    (p.tov || 0) * w.tov
-  );
-}
-
-function populateFilters() {
-  if (!isBrowser) return;
-  const teamSelect = document.getElementById('filter-team');
-  const posSelect = document.getElementById('filter-pos');
-  const teams = Array.from(new Set(players.map(p => p.team))).sort();
-  const positions = Array.from(new Set(players.map(p => p.pos))).sort();
-  teamSelect.innerHTML = '<option value="">All Teams</option>';
-  teams.forEach(t => {
-    const opt = document.createElement('option');
-    opt.value = t;
-    opt.textContent = t;
-    teamSelect.appendChild(opt);
   });
-  posSelect.innerHTML = '<option value="">All Positions</option>';
-  positions.forEach(pos => {
-    const opt = document.createElement('option');
-    opt.value = pos;
-    opt.textContent = pos;
-    posSelect.appendChild(opt);
-  });
-  document.getElementById('filter-name').oninput = renderProjections;
-  teamSelect.onchange = renderProjections;
-  posSelect.onchange = renderProjections;
-}
-
-function renderProjections() {
-  if (!isBrowser) return;
-  const tbody = document.querySelector('#projections-table tbody');
-  tbody.innerHTML = '';
-  const nameFilter = document.getElementById('filter-name').value.toLowerCase();
-  const teamFilter = document.getElementById('filter-team').value;
-  const posFilter = document.getElementById('filter-pos').value;
-  players
-    .filter(p =>
-      p.name.toLowerCase().includes(nameFilter) &&
-      (!teamFilter || p.team === teamFilter) &&
-      (!posFilter || p.pos === posFilter)
-    )
-    .forEach(p => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${p.name}</td><td>${p.team}</td><td>${p.pos}</td>` +
-        `<td>${p.pts}</td><td>${p.reb}</td><td>${p.ast}</td>` +
-        `<td>${p.stl}</td><td>${p.blk}</td><td>${p.tov}</td>` +
-        `<td>${p.fppg.toFixed(1)}</td>`;
-      tbody.appendChild(tr);
-    });
-}
-
-function computeValues() {
-  computeValuesFor(players, undrafted, teamCount, budgetPerTeam, spent, teamBudgets);
-}
-
-function computeValuesFor(list, undraftedSet, tCount, bPerTeam, spentTotal, budgets) {
-  const remaining = list.filter(p => undraftedSet.has(p.name));
-  if (remaining.length === 0) return { replacement: 0, totalPAR: 0, budgetLeft: 0 };
-  const sorted = remaining.map(p => p.fppg).sort((a, b) => b - a);
-  const index = Math.min(129, sorted.length - 1);
-  const replacement = sorted[index];
-  remaining.forEach(p => { p.par = Math.max(0, p.fppg - replacement); });
-  const totalPAR = remaining.reduce((sum, p) => sum + Math.max(0, p.par), 0);
-  const budgetLeft = budgets ? budgets.reduce((a, b) => a + b, 0)
-    : tCount * bPerTeam - spentTotal;
-  remaining.forEach(p => {
-    p.value = totalPAR > 0 ? budgetLeft * (Math.max(0, p.par) / totalPAR) : 0;
-  });
-  return { replacement, totalPAR, budgetLeft };
-}
-
-function renderDraft() {
-  computeValues();
-  if (!isBrowser) return;
-  const tbody = document.querySelector('#draft-table tbody');
-  tbody.innerHTML = '';
-  players.filter(p => undrafted.has(p.name)).forEach(p => {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${p.name}</td><td>${p.fppg.toFixed(1)}</td>` +
-      `<td>${p.par ? p.par.toFixed(1) : '0'}</td>` +
-      `<td>${p.value ? p.value.toFixed(1) : '0'}</td>`;
-    const teamTd = document.createElement('td');
-    const select = document.createElement('select');
-    teamNames.forEach((name, idx) => {
-      const opt = document.createElement('option');
-      opt.value = idx;
-      opt.textContent = name;
-      select.appendChild(opt);
-    });
-    teamTd.appendChild(select);
-    tr.appendChild(teamTd);
-    const priceTd = document.createElement('td');
-    const priceInput = document.createElement('input');
-    priceInput.type = 'number';
-    priceInput.min = '0';
-    priceInput.step = '0.1';
-    priceInput.value = p.value ? p.value.toFixed(1) : '0';
-    priceTd.appendChild(priceInput);
-    tr.appendChild(priceTd);
-    const td = document.createElement('td');
-    const btn = document.createElement('button');
-    btn.textContent = 'Draft';
-    btn.addEventListener('click', () => {
-      const teamIndex = parseInt(select.value, 10);
-      const price = parseFloat(priceInput.value);
-      if (!Number.isFinite(price) || price <= 0) return;
-      if (price > teamBudgets[teamIndex]) {
-        alert('Bid exceeds team budget');
-        return;
-      }
-      teamBudgets[teamIndex] -= price;
-      spent += price;
-      undrafted.delete(p.name);
-      rosters[teamIndex].push({ player: p, price });
-      renderDraft();
-      renderRosters();
-    });
-    td.appendChild(btn);
-    tr.appendChild(td);
-    tbody.appendChild(tr);
-  });
-  const budgetDiv = document.getElementById('budget-info');
-  const total = teamBudgets.reduce((a, b) => a + b, 0);
-  budgetDiv.innerHTML = `Total remaining budget: $${total.toFixed(1)}`;
-  const list = document.createElement('ul');
-  teamBudgets.forEach((b, i) => {
-    const li = document.createElement('li');
-    li.textContent = `${teamNames[i]}: $${b.toFixed(1)}`;
-    list.appendChild(li);
-  });
-  budgetDiv.appendChild(list);
-}
-
-function renderRosters() {
-  if (!isBrowser) return;
-  const container = document.getElementById('roster-list');
-  container.innerHTML = '';
-  rosters.forEach((team, i) => {
-    const div = document.createElement('div');
-    div.className = 'team-roster';
-    const h3 = document.createElement('h3');
-    h3.textContent = teamNames[i];
-    div.appendChild(h3);
-    const ul = document.createElement('ul');
-    team.forEach(entry => {
-      const li = document.createElement('li');
-      li.textContent = `${entry.player.name} - $${entry.price.toFixed(1)}`;
-      ul.appendChild(li);
-    });
-    div.appendChild(ul);
-    container.appendChild(div);
-  });
-}
-
-if (typeof module !== 'undefined') {
-  module.exports = { calcFPPG, computeValuesFor };
 }

--- a/index.html
+++ b/index.html
@@ -62,6 +62,6 @@
     <div id="roster-list"></div>
   </section>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/modules/design-system.js
+++ b/modules/design-system.js
@@ -1,0 +1,27 @@
+export const categories = {
+  pts: 'Points',
+  threepm: '3PM',
+  fga: 'FGA',
+  fgm: 'FGM',
+  fta: 'FTA',
+  ftm: 'FTM',
+  reb: 'REB',
+  ast: 'AST',
+  stl: 'STL',
+  blk: 'BLK',
+  tov: 'TOV'
+};
+
+export const defaultWeights = {
+  pts: 1,
+  threepm: 1,
+  fga: -1,
+  fgm: 2,
+  fta: -1,
+  ftm: 1,
+  reb: 1,
+  ast: 2,
+  stl: 4,
+  blk: 4,
+  tov: -2
+};

--- a/modules/draft.js
+++ b/modules/draft.js
@@ -1,0 +1,104 @@
+import { state } from './state.js';
+
+export function computeValues() {
+  computeValuesFor(state.players, state.undrafted, state.teamCount, state.budgetPerTeam, state.spent, state.teamBudgets);
+}
+
+export function computeValuesFor(list, undraftedSet, tCount, bPerTeam, spentTotal, budgets) {
+  const remaining = list.filter(p => undraftedSet.has(p.name));
+  if (remaining.length === 0) return { replacement: 0, totalPAR: 0, budgetLeft: 0 };
+  const sorted = remaining.map(p => p.fppg).sort((a, b) => b - a);
+  const index = Math.min(129, sorted.length - 1);
+  const replacement = sorted[index];
+  remaining.forEach(p => { p.par = Math.max(0, p.fppg - replacement); });
+  const totalPAR = remaining.reduce((sum, p) => sum + Math.max(0, p.par), 0);
+  const budgetLeft = budgets ? budgets.reduce((a, b) => a + b, 0)
+    : tCount * bPerTeam - spentTotal;
+  remaining.forEach(p => {
+    p.value = totalPAR > 0 ? budgetLeft * (Math.max(0, p.par) / totalPAR) : 0;
+  });
+  return { replacement, totalPAR, budgetLeft };
+}
+
+export function renderDraft() {
+  computeValues();
+  const tbody = document.querySelector('#draft-table tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  state.players.filter(p => state.undrafted.has(p.name)).forEach(p => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${p.name}</td><td>${p.fppg.toFixed(1)}</td>` +
+      `<td>${p.par ? p.par.toFixed(1) : '0'}</td>` +
+      `<td>${p.value ? p.value.toFixed(1) : '0'}</td>`;
+    const teamTd = document.createElement('td');
+    const select = document.createElement('select');
+    state.teamNames.forEach((name, idx) => {
+      const opt = document.createElement('option');
+      opt.value = idx;
+      opt.textContent = name;
+      select.appendChild(opt);
+    });
+    teamTd.appendChild(select);
+    tr.appendChild(teamTd);
+    const priceTd = document.createElement('td');
+    const priceInput = document.createElement('input');
+    priceInput.type = 'number';
+    priceInput.min = '0';
+    priceInput.step = '0.1';
+    priceInput.value = p.value ? p.value.toFixed(1) : '0';
+    priceTd.appendChild(priceInput);
+    tr.appendChild(priceTd);
+    const td = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Draft';
+    btn.addEventListener('click', () => {
+      const teamIndex = parseInt(select.value, 10);
+      const price = parseFloat(priceInput.value);
+      if (!Number.isFinite(price) || price <= 0) return;
+      if (price > state.teamBudgets[teamIndex]) {
+        alert('Bid exceeds team budget');
+        return;
+      }
+      state.teamBudgets[teamIndex] -= price;
+      state.spent += price;
+      state.undrafted.delete(p.name);
+      state.rosters[teamIndex].push({ player: p, price });
+      renderDraft();
+      renderRosters();
+    });
+    td.appendChild(btn);
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  });
+  const budgetDiv = document.getElementById('budget-info');
+  const total = state.teamBudgets.reduce((a, b) => a + b, 0);
+  budgetDiv.innerHTML = `Total remaining budget: $${total.toFixed(1)}`;
+  const list = document.createElement('ul');
+  state.teamBudgets.forEach((b, i) => {
+    const li = document.createElement('li');
+    li.textContent = `${state.teamNames[i]}: $${b.toFixed(1)}`;
+    list.appendChild(li);
+  });
+  budgetDiv.appendChild(list);
+}
+
+export function renderRosters() {
+  const container = document.getElementById('roster-list');
+  if (!container) return;
+  container.innerHTML = '';
+  state.rosters.forEach((team, i) => {
+    const div = document.createElement('div');
+    div.className = 'team-roster';
+    const h3 = document.createElement('h3');
+    h3.textContent = state.teamNames[i];
+    div.appendChild(h3);
+    const ul = document.createElement('ul');
+    team.forEach(entry => {
+      const li = document.createElement('li');
+      li.textContent = `${entry.player.name} - $${entry.price.toFixed(1)}`;
+      ul.appendChild(li);
+    });
+    div.appendChild(ul);
+    container.appendChild(div);
+  });
+}

--- a/modules/eligibility.js
+++ b/modules/eligibility.js
@@ -1,0 +1,3 @@
+export function positionsFor(player) {
+  return player.pos ? [player.pos] : [];
+}

--- a/modules/optimizers.js
+++ b/modules/optimizers.js
@@ -1,0 +1,4 @@
+export function optimizeLineup(players) {
+  // simple placeholder returning players unchanged
+  return players;
+}

--- a/modules/overrides.js
+++ b/modules/overrides.js
@@ -1,0 +1,1 @@
+export const overrides = {};

--- a/modules/router.js
+++ b/modules/router.js
@@ -1,0 +1,9 @@
+export function initTabs() {
+  document.querySelectorAll('nav button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      document.querySelectorAll('.tab').forEach(s => s.hidden = true);
+      document.getElementById(tab).hidden = false;
+    });
+  });
+}

--- a/modules/scoring.js
+++ b/modules/scoring.js
@@ -8,3 +8,33 @@ export function fppg(perGame, w) {
     get('FTM') * (w.FTM ?? 0) + get('FTA') * (w.FTA ?? 0)
   );
 }
+
+export function calcFPPG(player, weights) {
+  const per = {
+    PTS: player.pts,
+    REB: player.reb,
+    AST: player.ast,
+    STL: player.stl,
+    BLK: player.blk,
+    TOV: player.tov,
+    '3PM': player.threepm,
+    FGM: player.fgm,
+    FGA: player.fga,
+    FTM: player.ftm,
+    FTA: player.fta
+  };
+  const w = {
+    PTS: weights.pts,
+    REB: weights.reb,
+    AST: weights.ast,
+    STL: weights.stl,
+    BLK: weights.blk,
+    TOV: weights.tov,
+    '3PM': weights.threepm,
+    FGM: weights.fgm,
+    FGA: weights.fga,
+    FTM: weights.ftm,
+    FTA: weights.fta
+  };
+  return fppg(per, w);
+}

--- a/modules/state.js
+++ b/modules/state.js
@@ -1,0 +1,43 @@
+import { defaultWeights } from './design-system.js';
+
+export const state = {
+  players: [],
+  undrafted: new Set(),
+  teamCount: 10,
+  budgetPerTeam: 200,
+  season: 2025,
+  teamBudgets: [],
+  spent: 0,
+  teamNames: [],
+  rosters: [],
+  weights: { ...defaultWeights }
+};
+
+export function initState() {
+  state.teamBudgets = Array(state.teamCount).fill(state.budgetPerTeam);
+  state.teamNames = Array.from({ length: state.teamCount }, (_, i) => `Team ${i + 1}`);
+  state.rosters = Array.from({ length: state.teamCount }, () => []);
+}
+
+export function applySettingsFromDOM() {
+  const t = parseInt(document.getElementById('teams').value, 10);
+  const b = parseFloat(document.getElementById('budget').value);
+  const s = parseInt(document.getElementById('season').value, 10);
+  state.teamCount = Number.isInteger(t) && t > 0 ? t : state.teamCount;
+  state.budgetPerTeam = Number.isFinite(b) && b > 0 ? b : state.budgetPerTeam;
+  const oldSeason = state.season;
+  state.season = Number.isInteger(s) ? s : state.season;
+  const namesInput = document.getElementById('team-names').value.trim();
+  let names = namesInput ? namesInput.split(',').map(n => n.trim()).filter(Boolean) : [];
+  while (names.length < state.teamCount) names.push(`Team ${names.length + 1}`);
+  state.teamNames = names.slice(0, state.teamCount);
+  document.getElementById('team-names').value = state.teamNames.join(', ');
+  document.querySelectorAll('#weights input').forEach(input => {
+    const val = parseFloat(input.value);
+    state.weights[input.dataset.cat] = Number.isFinite(val) ? val : 0;
+  });
+  state.teamBudgets = Array(state.teamCount).fill(state.budgetPerTeam);
+  state.spent = 0;
+  state.rosters = Array.from({ length: state.teamCount }, () => []);
+  return oldSeason !== state.season;
+}

--- a/modules/storage.js
+++ b/modules/storage.js
@@ -1,0 +1,11 @@
+export function save(key, value) {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+}
+
+export function load(key, def) {
+  if (typeof localStorage === 'undefined') return def;
+  const raw = localStorage.getItem(key);
+  return raw ? JSON.parse(raw) : def;
+}

--- a/modules/table.js
+++ b/modules/table.js
@@ -1,0 +1,24 @@
+import { state } from './state.js';
+
+export function renderProjections() {
+  const tbody = document.querySelector('#projections-table tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  const nameFilter = document.getElementById('filter-name').value.toLowerCase();
+  const teamFilter = document.getElementById('filter-team').value;
+  const posFilter = document.getElementById('filter-pos').value;
+  state.players
+    .filter(p =>
+      p.name.toLowerCase().includes(nameFilter) &&
+      (!teamFilter || p.team === teamFilter) &&
+      (!posFilter || p.pos === posFilter)
+    )
+    .forEach(p => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${p.name}</td><td>${p.team}</td><td>${p.pos}</td>` +
+        `<td>${p.pts}</td><td>${p.reb}</td><td>${p.ast}</td>` +
+        `<td>${p.stl}</td><td>${p.blk}</td><td>${p.tov}</td>` +
+        `<td>${p.fppg.toFixed(1)}</td>`;
+      tbody.appendChild(tr);
+    });
+}

--- a/modules/tiers.js
+++ b/modules/tiers.js
@@ -1,0 +1,4 @@
+export function tierPlayers(players) {
+  // placeholder for tier calculation
+  return [];
+}

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -1,0 +1,42 @@
+import { categories } from './design-system.js';
+import { state } from './state.js';
+
+export function renderWeightInputs() {
+  const container = document.getElementById('weights');
+  container.innerHTML = '';
+  Object.entries(state.weights).forEach(([key, val]) => {
+    const label = document.createElement('label');
+    label.textContent = `${categories[key]}: `;
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.1';
+    input.value = val;
+    input.dataset.cat = key;
+    label.appendChild(input);
+    container.appendChild(label);
+  });
+}
+
+export function populateFilters(players, onChange) {
+  const teamSelect = document.getElementById('filter-team');
+  const posSelect = document.getElementById('filter-pos');
+  const teams = Array.from(new Set(players.map(p => p.team))).sort();
+  const positions = Array.from(new Set(players.map(p => p.pos))).sort();
+  teamSelect.innerHTML = '<option value="">All Teams</option>';
+  teams.forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    teamSelect.appendChild(opt);
+  });
+  posSelect.innerHTML = '<option value="">All Positions</option>';
+  positions.forEach(pos => {
+    const opt = document.createElement('option');
+    opt.value = pos;
+    opt.textContent = pos;
+    posSelect.appendChild(opt);
+  });
+  document.getElementById('filter-name').oninput = onChange;
+  teamSelect.onchange = onChange;
+  posSelect.onchange = onChange;
+}

--- a/modules/weeks.js
+++ b/modules/weeks.js
@@ -1,0 +1,3 @@
+export function currentWeek() {
+  return 1;
+}

--- a/modules/workers/calc.worker.js
+++ b/modules/workers/calc.worker.js
@@ -1,0 +1,5 @@
+self.onmessage = e => {
+  const { players = [] } = e.data || {};
+  // simple worker echoing back player names
+  postMessage(players.map(p => p.name));
+};


### PR DESCRIPTION
## Summary
- Move core logic from monolithic script into modules (state, router, UI, tables, data, draft, scoring)
- Add foundational design-system, storage, eligibility, and placeholder modules plus worker
- Load app via ES module and initialize routing, state, and event wiring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a64219022c83228e27d4beb70af5c3