### PR TITLE
Implement auction valuations and draft market recompute

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import { initState, state, applySettingsFromDOM, memoFPPG, setCachedFPPG } from 
 import { initTabs } from './modules/router.js';
 import { renderWeightInputs, populateFilters } from './modules/ui.js';
 import { renderProjections } from './modules/table.js';
-import { renderDraft, renderRosters } from './modules/draft.js';
+import { renderDraft, renderRosters, setCalcWorker } from './modules/draft.js';
 import { fetchTotals, fetchAdvanced, normalizePlayers } from './modules/data-nbaapi.js';
 
 async function loadPlayers(season, weights) {
@@ -50,6 +50,7 @@ if (typeof window !== 'undefined') {
     renderDraft();
 
     const worker = new Worker(new URL('./modules/workers/calc.worker.js', import.meta.url), { type: 'module' });
+    setCalcWorker(worker);
 
     let weightTimer;
     function scheduleWeights() {

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <table id="draft-table">
       <thead>
         <tr>
-          <th>Player</th><th>FPPG</th><th>PAR</th><th>Value ($)</th><th>Team</th><th>Bid</th><th></th>
+          <th>Player</th><th>FPPG</th><th>PAR</th><th>Value ($)</th><th>Rec Bid</th><th>Tier</th><th>Team</th><th>Bid</th><th></th>
         </tr>
       </thead>
       <tbody></tbody>

--- a/modules/tiers.js
+++ b/modules/tiers.js
@@ -1,4 +1,16 @@
 export function tierPlayers(players) {
-  // placeholder for tier calculation
-  return [];
+  if (!Array.isArray(players) || players.length === 0) return new Map();
+  const sorted = [...players].sort((a, b) => b.fppg - a.fppg);
+  const n = sorted.length;
+  const result = new Map();
+  sorted.forEach((p, i) => {
+    const pct = (i + 1) / n;
+    let tier = 5;
+    if (pct <= 0.2) tier = 1;
+    else if (pct <= 0.4) tier = 2;
+    else if (pct <= 0.6) tier = 3;
+    else if (pct <= 0.8) tier = 4;
+    result.set(p.id, tier);
+  });
+  return result;
 }


### PR DESCRIPTION
## Summary
- Implement player valuation calculations including PAR, Base$, $Now, competitor caps, scarcity multiplier and spend-curve normalization
- Rework draft module to maintain market state, trigger worker recomputations, and render recommended bid with tiers in the Draft tab
- Add basic tiering utility and update Draft table columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6535440a08322a222980fb865baf9