### PR TITLE
feat: add hash-based tab navigation

### DIFF
--- a/modules/router.js
+++ b/modules/router.js
@@ -1,9 +1,30 @@
 export function initTabs() {
+  function showTab(tab) {
+    if (!tab) return;
+    document.querySelectorAll('.tab').forEach(section => {
+      section.hidden = true;
+    });
+    const active = document.getElementById(tab);
+    if (active) active.hidden = false;
+
+    document.querySelectorAll('nav button').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.tab === tab);
+    });
+  }
+
   document.querySelectorAll('nav button').forEach(btn => {
     btn.addEventListener('click', () => {
       const tab = btn.dataset.tab;
-      document.querySelectorAll('.tab').forEach(s => s.hidden = true);
-      document.getElementById(tab).hidden = false;
+      // update hash so tab can be bookmarked or restored on reload
+      window.location.hash = tab;
+      showTab(tab);
     });
   });
+
+  window.addEventListener('hashchange', () => {
+    showTab(window.location.hash.substring(1));
+  });
+
+  // show initial tab based on hash or default to settings
+  showTab(window.location.hash.substring(1) || 'settings');
 }

--- a/style.css
+++ b/style.css
@@ -34,6 +34,10 @@ nav button:hover {
   opacity: 0.85;
 }
 
+nav button.active {
+  background: var(--primary-color);
+}
+
 table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
## Summary
- enable hash-based tab navigation and active-state styling for buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6560cd88c832285fb49016f1a7cd0